### PR TITLE
Fix dow rules

### DIFF
--- a/lib/DateTime/TimeZone/Zone.pm6
+++ b/lib/DateTime/TimeZone/Zone.pm6
@@ -55,10 +55,10 @@ method offset {
                                    hour => +@time[0],
                                    minute => +@time[1]);
           my $day;
-          if $rule<dow><dow> <= $datetime.day-of-week {
-            $day = $datetime.day-of-week - $rule<dow><dow>;
+          if $datetime.day-of-week <= $rule<lastdow> {
+            $day = $rule<lastdow> - $datetime.day-of-week;
           } else {
-            $day = 7 - ($rule<dow><dow> - $datetime.day-of-week);
+            $day = 7 - ($datetime.day-of-week - $rule<lastdow>);
           }
           $datetime .= later(days => $day);
 
@@ -77,10 +77,10 @@ method offset {
                                    hour => +@time[0],
                                    minute => +@time[1]);
           my $day;
-          if $rule<dow><dow> <= $datetime.day-of-week {
-            $day = $datetime.day-of-week - $rule<dow><dow>;
+          if $datetime.day-of-week <= $rule<dow><dow> {
+            $day = $rule<dow><dow> - $datetime.day-of-week;
           } else {
-            $day = 7 - ($rule<dow><dow> - $datetime.day-of-week);
+            $day = 7 - ($datetime.day-of-week - $rule<dow><dow>);
           }
           while $day < $rule<dow><mindate> {
             $day += 7;

--- a/t/timezone.t
+++ b/t/timezone.t
@@ -1,0 +1,48 @@
+#!/usr/bin/env perl6
+
+use v6;
+
+use lib './lib';
+
+use Test;
+use DateTime::TimeZone;
+
+plan 4;
+
+# Relevant entries in the tz database:
+#
+# #Rule NAME    FROM TO   TYPE IN  ON      AT   SAVE LETTER
+# Rule  Chicago 1922 1966  -   Apr lastSun 2:00 1:00 D
+# Rule  Chicago 1922 1954  -   Sep lastSun 2:00 0    S
+#
+# #Zone NAME            STDOFF RULES   FORMAT [UNTIL]
+# Zone  America/Chicago -6:00  Chicago C%sT   1936 Mar  1  2:00
+
+# April 1st 1923 was a Sunday
+# April 29th 1923 was the last Sunday of April
+is timezone('America/Chicago', DateTime.new(
+        year => 1923, month => 4, day => 28,
+        hour => 15, minute => 1, second => 1)).Int,
+    tz-offset('-0600'),
+    'Correct offset with lastSun rule and first day of month == Sunday (day before)';
+
+is timezone('America/Chicago', DateTime.new(
+        year => 1923, month => 4, day => 29,
+        hour => 15, minute => 1, second => 1)).Int,
+    tz-offset('-0500'),
+    'Correct offset with lastSun rule and first day of month == Sunday (day after)';
+
+# April 1st 1924 was a Tuesday
+# April 27sh 1924 was the last Sunday of April
+is timezone('America/Chicago', DateTime.new(
+        year => 1924, month => 4, day => 26,
+        hour => 15, minute => 1, second => 1)).Int,
+    tz-offset('-0600'),
+    'Correct offset with lastSun rule and first day of month == Tuesday (day before)';
+
+is timezone('America/Chicago', DateTime.new(
+        year => 1924, month => 4, day => 27,
+        hour => 15, minute => 1, second => 1)).Int,
+    tz-offset('-0500'),
+    'Correct offset with lastSun rule and first day of month == Tuesday (day after)';
+


### PR DESCRIPTION
Two errors were fixed:
- When a `<lastdow>` day was given in the DB, the code tried to access the
  `<dow><dow>` day. That's not in the DB then. Fixed by changing the
  accesses to `<lastdow>`. That was probably a copy-and-paste error.
- The calculation of the last day of the month that is a given weekday
  (lastdow) was wrong. The same error applied for day of week after some
  day calulations (dow). Before this fix the timezone offset was wrong for
  dates close to a change of the offset. This applied to a big part of all
  daylight saving rules.

I added some tests to exercise `timezone()`. The tests failed before above
fixes and now succeed.